### PR TITLE
Mistake in code example in Interactive.hs

### DIFF
--- a/src/ChaosBox/Interactive.hs
+++ b/src/ChaosBox/Interactive.hs
@@ -23,7 +23,7 @@
 -- let centerCircle = 'Circle' center 0
 -- circleRef <- 'newIORef' centerCircle
 --
--- 'onMouseDown' $ \p -> do
+-- 'onMouseDown' ButtonLeft $ \p -> do
 --  'modifyIORefM_' circleRef $ \c -> do
 --    newCenter <- 'normal' p 1
 --    let newRadius = 'circleRadius' c + 0.1


### PR DESCRIPTION
Hi,

At the top of the Interactive.hs file there is a code example using mouse events, but the function `onMouseDown` used there only takes an action, while the actual function also needs a button type. A consequence of an API change, I suppose. This pull request should fix it.