### PR TITLE
Remove the Affine type class in favor of a simpler approach

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                chaosbox
-version:             0.0.0.1
+version:             0.0.0.2
 synopsis: A Generative Art Framework
 description: A Generative Art Framework
 homepage:            https://github.com/5outh/chaosbox#readme

--- a/src/ChaosBox/Affine.hs
+++ b/src/ChaosBox/Affine.hs
@@ -2,12 +2,10 @@
 module ChaosBox.Affine
   (
   -- * Data Types
-    Affine(..)
-  , Transform2d(..)
+    Transform2d(..)
   , defaultTransform
   , withCairoAffine
   , matrix
-  , transformMatrix
   -- * Transformations
   , rotated
   , translated
@@ -54,25 +52,6 @@ instance Monoid Transform2d where
 -- | Create a 'Transform2d' from a 3x3 matrix ('M33')
 matrix :: M33 Double -> Transform2d
 matrix = Transform2d
-
--- | A class of items transformable via linear transformations
-class Affine a where
-  type Transformed a :: *
-  -- ^ The type of item produced after applying an 'Affine' transformation to
-  -- 'a'. Most of the time, @Transformed a ~ a@. However, sometimes an 'Affine'
-  -- transformation can change the underlying type of a shape.
-  --
-  -- For example, when 'ChaosBox.Geometry.Circle.Circle's are 'transform'ed
-  -- with a scalar in one direction, an 'ChaosBox.Geometry.Ellipse.Ellipse' is
-  -- formed.
-  type Transformed a = a
-
-  -- Apply a 'Transform2d' to an 'Affine'
-  transform :: Transform2d -> a -> Transformed a
-
--- | 'transform' an 'Affine' using a 3x3 matrix ('M33')
-transformMatrix :: Affine a => M33 Double -> a -> Transformed a
-transformMatrix = transform . matrix
 
 -- | A useful default 'transform' for 'Functor's over 2D coordinates
 --

--- a/src/ChaosBox/Geometry/Angle.hs
+++ b/src/ChaosBox/Geometry/Angle.hs
@@ -6,11 +6,13 @@ module ChaosBox.Geometry.Angle
   , unit
   , addRadians
   , addDegrees
+  , rotateP2
+  , rotateP2Around
   )
 where
 
 import           ChaosBox.Geometry.P2
-import           Data.Fixed                     ( mod' )
+import           Data.Fixed           (mod')
 import           Linear.V2
 
 newtype Angle = Angle { getAngle :: Double }
@@ -48,3 +50,22 @@ addRadians theta (Angle a) = Angle (theta + a)
 --
 addDegrees :: Double -> Angle -> Angle
 addDegrees theta (Angle a) = Angle (theta * pi / 180 + a)
+
+-- | Rotate a 'P2' about the origin (@(0,0)@)
+rotateP2 :: Angle -> P2 -> P2
+rotateP2 (Angle theta) (P2 x0 y0) = P2 x y
+ where
+  x = x0 * cos theta - y0 * sin theta
+  y = x0 * sin theta + y0 * cos theta
+
+-- | Rotate a 'P2' around a specified point
+rotateP2Around
+  :: P2
+  -- ^ Point to rotate around
+  -> Angle
+  -- ^ Rotation angle
+  -> P2
+  -- ^ Point to rotate
+  -> P2
+rotateP2Around center theta point =
+  translateP2 center (rotateP2 theta (translateP2 (-center) point))

--- a/src/ChaosBox/Geometry/Arc.hs
+++ b/src/ChaosBox/Geometry/Arc.hs
@@ -85,10 +85,10 @@ arcPoints ArcOf {..} = points
 translateArc :: P2 -> Arc -> Arc
 translateArc p2 = fmap (translateP2 p2)
 
-scaleArc :: Double -> Arc -> Arc
+scaleArc :: P2 -> Arc -> Arc
 scaleArc amount = fmap (scaleP2 amount)
 
-scaleArcAround :: P2 -> Double -> Arc -> Arc
+scaleArcAround :: P2 -> P2 -> Arc -> Arc
 scaleArcAround center amount = fmap (scaleP2Around center amount)
 
 rotateArc :: Angle -> Arc -> Arc

--- a/src/ChaosBox/Geometry/ClosedCurve.hs
+++ b/src/ChaosBox/Geometry/ClosedCurve.hs
@@ -10,21 +10,26 @@ module ChaosBox.Geometry.ClosedCurve
   , drawWithDetail
   , fromPolygon
   , toPolygon
+  , translateClosedCurve
+  , scaleClosedCurve
+  , scaleClosedCurveAround
+  , rotateClosedCurve
+  , rotateClosedCurveAround
   )
 where
 
 import           ChaosBox.AABB
-import           ChaosBox.Affine
 import           ChaosBox.Draw
+import           ChaosBox.Geometry.Angle
 import           ChaosBox.Geometry.Class
 import           ChaosBox.Geometry.P2
 import           ChaosBox.Geometry.Polygon
+import           ChaosBox.Geometry.Transform
 import           Control.Lens
 import           Data.Foldable
-import           Data.List.NonEmpty        (NonEmpty)
-import qualified Data.List.NonEmpty        as NE
-import           GI.Cairo.Render           (Render)
-import           Linear                    ((*^))
+import           Data.List.NonEmpty          (NonEmpty)
+import qualified Data.List.NonEmpty          as NE
+import           GI.Cairo.Render             (Render)
 
 -- | Closed Cubic B-Spline
 data ClosedCurveOf a = ClosedCurveOf { getClosedCurveOf :: NonEmpty a, closedCurveOfIterations :: Int }
@@ -44,9 +49,6 @@ closedCurve = closedCurveOf @P2
 
 instance HasP2 a => HasAABB (ClosedCurveOf a) where
   aabb = boundary .getClosedCurveOf
-
-instance HasP2 a => Affine (ClosedCurveOf a) where
-  transform = defaultTransform
 
 instance HasP2 a => Draw (ClosedCurveOf a) where
   draw = drawWithDetail
@@ -83,12 +85,17 @@ fromPolygon (PolygonOf p) = ClosedCurveOf p 5
 iterateNLast :: Int -> (a -> a) -> a -> a
 iterateNLast n f x = last . take n $ iterate f x
 
-quads (a:xs@(b:c:d:_)) = (a,b,c,d):quads xs
-quads _                = []
+translateClosedCurve :: HasP2 a => P2 -> ClosedCurveOf a -> ClosedCurveOf a
+translateClosedCurve = translatePoints
 
-catmullRom :: Double -> P2 -> P2 -> P2 -> P2 -> P2
-catmullRom t p_1 p0 p1 p2 =
-           (t*((2-t)*t - 1)   *^ p_1
-         + (t*t*(3*t - 5) + 2) *^ p0
-         + t*((4 - 3*t)*t + 1) *^ p1
-         + (t-1)*t*t         *^ p2 ) / 2
+scaleClosedCurve :: HasP2 a => P2 -> ClosedCurveOf a -> ClosedCurveOf a
+scaleClosedCurve = scalePoints
+
+scaleClosedCurveAround :: HasP2 a => P2 -> P2 -> ClosedCurveOf a -> ClosedCurveOf a
+scaleClosedCurveAround = scaleAroundPoints
+
+rotateClosedCurve :: HasP2 a => Angle -> ClosedCurveOf a -> ClosedCurveOf a
+rotateClosedCurve = rotatePoints
+
+rotateClosedCurveAround :: HasP2 a => P2 -> Angle -> ClosedCurveOf a -> ClosedCurveOf a
+rotateClosedCurveAround = rotateAroundPoints

--- a/src/ChaosBox/Geometry/Curve.hs
+++ b/src/ChaosBox/Geometry/Curve.hs
@@ -14,7 +14,6 @@ module ChaosBox.Geometry.Curve
 where
 
 import           ChaosBox.AABB
-import           ChaosBox.Affine
 import           ChaosBox.Draw
 import           ChaosBox.Geometry.Class
 import           ChaosBox.Geometry.P2
@@ -36,9 +35,6 @@ pattern Curve {getCurve, curveIterations} = CurveOf getCurve curveIterations
 
 instance HasP2 a => HasAABB (CurveOf a) where
   aabb = aabb . toPath
-
-instance HasP2 a => Affine (CurveOf a) where
-  transform = defaultTransform
 
 instance HasP2 a => Draw (CurveOf a) where
   draw = drawWithDetail

--- a/src/ChaosBox/Geometry/Line.hs
+++ b/src/ChaosBox/Geometry/Line.hs
@@ -6,19 +6,26 @@ module ChaosBox.Geometry.Line
   , pattern Line
   , lineStart
   , lineEnd
+  -- * Transforming 'Line's
+  , translateLine
+  , scaleLine
+  , scaleLineAround
+  , rotateLine
+  , rotateLineAround
   )
 where
 
 import           ChaosBox.AABB
-import           ChaosBox.Affine
 import           ChaosBox.Draw
+import           ChaosBox.Geometry.Angle
 import           ChaosBox.Geometry.Class
 import           ChaosBox.Geometry.P2
 import           ChaosBox.Geometry.Path
+import           ChaosBox.Geometry.Transform
 import           Data.List.NonEmpty
-import           Data.Maybe              (maybeToList)
-import           Linear.V2               (V2 (..))
-import           Linear.Vector           ((*^))
+import           Data.Maybe                  (maybeToList)
+import           Linear.V2                   (V2 (..))
+import           Linear.Vector               ((*^))
 
 data LineOf a = LineOf { lineOfStart :: a, lineOfEnd :: a}
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
@@ -31,9 +38,6 @@ pattern Line { lineStart, lineEnd } = LineOf lineStart lineEnd
 
 instance HasP2 a => HasAABB (LineOf a) where
   aabb LineOf {..} = boundary $ lineOfStart :| [lineOfEnd]
-
-instance HasP2 a => Affine (LineOf a) where
-  transform = defaultTransform
 
 instance HasP2 a => Draw (LineOf a) where
   draw LineOf {..} = draw $ PathOf (lineOfStart :| [lineOfEnd])
@@ -62,3 +66,18 @@ segmentIntersectionPoint (fmap getP2 -> LineOf { lineOfStart = p, lineOfEnd = pr
 
 cross2 :: P2 -> P2 -> Double
 V2 vx vy `cross2` V2 wx wy = (vx * wy) - (vy * wx)
+
+translateLine :: HasP2 a => P2 -> LineOf a -> LineOf a
+translateLine = translatePoints
+
+scaleLine :: HasP2 a => Double -> LineOf a -> LineOf a
+scaleLine = scalePoints
+
+scaleLineAround :: HasP2 a => P2 -> Double -> LineOf a -> LineOf a
+scaleLineAround = scaleAroundPoints
+
+rotateLine :: HasP2 a => Angle -> LineOf a -> LineOf a
+rotateLine = rotatePoints
+
+rotateLineAround :: HasP2 a => P2 -> Angle -> LineOf a -> LineOf a
+rotateLineAround = rotateAroundPoints

--- a/src/ChaosBox/Geometry/Line.hs
+++ b/src/ChaosBox/Geometry/Line.hs
@@ -70,10 +70,10 @@ V2 vx vy `cross2` V2 wx wy = (vx * wy) - (vy * wx)
 translateLine :: HasP2 a => P2 -> LineOf a -> LineOf a
 translateLine = translatePoints
 
-scaleLine :: HasP2 a => Double -> LineOf a -> LineOf a
+scaleLine :: HasP2 a => P2 -> LineOf a -> LineOf a
 scaleLine = scalePoints
 
-scaleLineAround :: HasP2 a => P2 -> Double -> LineOf a -> LineOf a
+scaleLineAround :: HasP2 a => P2 -> P2 -> LineOf a -> LineOf a
 scaleLineAround = scaleAroundPoints
 
 rotateLine :: HasP2 a => Angle -> LineOf a -> LineOf a

--- a/src/ChaosBox/Geometry/P2.hs
+++ b/src/ChaosBox/Geometry/P2.hs
@@ -7,7 +7,6 @@ module ChaosBox.Geometry.P2
   )
 where
 
-import           Linear    ((*^))
 import           Linear.V2
 
 -- | A monomorphized 'V2'
@@ -31,15 +30,15 @@ pattern P2 x y = V2 x y
 translateP2 :: P2 -> P2 -> P2
 translateP2 offset p2 = p2 - offset
 
--- | Scale a 'P2' around the origin (@(0,0)@) by a scalar
-scaleP2 :: Double -> P2 -> P2
-scaleP2 = (*^)
+-- | Scale a 'P2' around the origin (@(0,0)@) by a 2d scalar
+scaleP2 :: P2 -> P2 -> P2
+scaleP2 (P2 x1 y1) (P2 x2 y2) = P2 (x1*x2) (y1*y2)
 
 -- | Scale a 'P2' around the specified point
 scaleP2Around
   :: P2
   -- ^ Point to scale around
-  -> Double
+  -> P2
   -- ^ Scalar
   -> P2
   -- ^ Point to scale

--- a/src/ChaosBox/Geometry/P2.hs
+++ b/src/ChaosBox/Geometry/P2.hs
@@ -1,9 +1,13 @@
 module ChaosBox.Geometry.P2
   ( P2
   , pattern P2
+  , translateP2
+  , scaleP2
+  , scaleP2Around
   )
 where
 
+import           Linear    ((*^))
 import           Linear.V2
 
 -- | A monomorphized 'V2'
@@ -22,3 +26,22 @@ type P2 = V2 Double
 pattern P2 :: Double -> Double -> P2
 pattern P2 x y = V2 x y
 {-# COMPLETE P2 #-}
+
+-- | Translate a 'P2' by an offset vector
+translateP2 :: P2 -> P2 -> P2
+translateP2 offset p2 = p2 - offset
+
+-- | Scale a 'P2' around the origin (@(0,0)@) by a scalar
+scaleP2 :: Double -> P2 -> P2
+scaleP2 = (*^)
+
+-- | Scale a 'P2' around the specified point
+scaleP2Around
+  :: P2
+  -- ^ Point to scale around
+  -> Double
+  -- ^ Scalar
+  -> P2
+  -- ^ Point to scale
+  -> P2
+scaleP2Around center amount p2 = translateP2 center (scaleP2 amount (translateP2 (-center) p2))

--- a/src/ChaosBox/Geometry/Path.hs
+++ b/src/ChaosBox/Geometry/Path.hs
@@ -4,25 +4,22 @@ module ChaosBox.Geometry.Path
   , Path
   , pattern Path
   , getPath
-  , pathOf
-  , path
   )
 where
 
 import           ChaosBox.Prelude
 
 import           ChaosBox.AABB
-import           ChaosBox.Affine
 import           ChaosBox.Draw
+import           ChaosBox.Geometry.Angle
 import           ChaosBox.Geometry.Class
 import           ChaosBox.Geometry.P2
 import           Control.Lens            ((^.))
 import           Data.Foldable           (for_)
 import           Data.List.NonEmpty      (NonEmpty (..))
-import qualified Data.List.NonEmpty      as NE
 import           GI.Cairo.Render         hiding (Path)
 
-newtype PathOf a = PathOf { getPathOf :: NonEmpty a}
+newtype PathOf a = PathOf { getPathOf :: NonEmpty a }
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
   deriving newtype (Applicative, Monad)
 
@@ -33,9 +30,6 @@ pattern Path :: NonEmpty P2 -> Path
 pattern Path { getPath } = PathOf getPath
 {-# COMPLETE Path #-}
 
-instance HasP2 a => Affine (PathOf a) where
-  transform = defaultTransform
-
 instance HasP2 a => Draw (PathOf a) where
   draw (PathOf (start :| rest)) = do
     newPath
@@ -45,8 +39,17 @@ instance HasP2 a => Draw (PathOf a) where
 instance HasP2 a => HasAABB (PathOf a) where
   aabb = boundary . getPathOf
 
-pathOf :: [a] -> Maybe (PathOf a)
-pathOf xs = PathOf <$> NE.nonEmpty xs
+translatePath :: P2 -> Path -> Path
+translatePath p2 = fmap (translateP2 p2)
 
-path :: [P2] -> Maybe Path
-path = pathOf @P2
+scalePath :: Double -> Path -> Path
+scalePath amount = fmap (scaleP2 amount)
+
+scalePathAround :: P2 -> Double -> Path -> Path
+scalePathAround center amount = fmap (scaleP2Around center amount)
+
+rotatePath :: Angle -> Path -> Path
+rotatePath theta = fmap (rotateP2 theta)
+
+rotatePathAround :: P2 -> Angle -> Path -> Path
+rotatePathAround center theta = fmap (rotateP2Around center theta)

--- a/src/ChaosBox/Geometry/Path.hs
+++ b/src/ChaosBox/Geometry/Path.hs
@@ -4,6 +4,11 @@ module ChaosBox.Geometry.Path
   , Path
   , pattern Path
   , getPath
+  , translatePath
+  , scalePath
+  , scalePathAround
+  , rotatePath
+  , rotatePathAround
   )
 where
 
@@ -14,10 +19,11 @@ import           ChaosBox.Draw
 import           ChaosBox.Geometry.Angle
 import           ChaosBox.Geometry.Class
 import           ChaosBox.Geometry.P2
-import           Control.Lens            ((^.))
-import           Data.Foldable           (for_)
-import           Data.List.NonEmpty      (NonEmpty (..))
-import           GI.Cairo.Render         hiding (Path)
+import           ChaosBox.Geometry.Transform
+import           Control.Lens                ((^.))
+import           Data.Foldable               (for_)
+import           Data.List.NonEmpty          (NonEmpty (..))
+import           GI.Cairo.Render             hiding (Path)
 
 newtype PathOf a = PathOf { getPathOf :: NonEmpty a }
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
@@ -39,17 +45,17 @@ instance HasP2 a => Draw (PathOf a) where
 instance HasP2 a => HasAABB (PathOf a) where
   aabb = boundary . getPathOf
 
-translatePath :: P2 -> Path -> Path
-translatePath p2 = fmap (translateP2 p2)
+translatePath :: HasP2 a => P2 -> PathOf a -> PathOf a
+translatePath = translatePoints
 
-scalePath :: Double -> Path -> Path
-scalePath amount = fmap (scaleP2 amount)
+scalePath :: HasP2 a => Double -> PathOf a -> PathOf a
+scalePath = scalePoints
 
-scalePathAround :: P2 -> Double -> Path -> Path
-scalePathAround center amount = fmap (scaleP2Around center amount)
+scalePathAround :: HasP2 a => P2 -> Double -> PathOf a -> PathOf a
+scalePathAround = scaleAroundPoints
 
-rotatePath :: Angle -> Path -> Path
-rotatePath theta = fmap (rotateP2 theta)
+rotatePath :: HasP2 a => Angle -> PathOf a -> PathOf a
+rotatePath = rotatePoints
 
-rotatePathAround :: P2 -> Angle -> Path -> Path
-rotatePathAround center theta = fmap (rotateP2Around center theta)
+rotatePathAround :: HasP2 a => P2 -> Angle -> PathOf a -> PathOf a
+rotatePathAround = rotateAroundPoints

--- a/src/ChaosBox/Geometry/Path.hs
+++ b/src/ChaosBox/Geometry/Path.hs
@@ -48,10 +48,10 @@ instance HasP2 a => HasAABB (PathOf a) where
 translatePath :: HasP2 a => P2 -> PathOf a -> PathOf a
 translatePath = translatePoints
 
-scalePath :: HasP2 a => Double -> PathOf a -> PathOf a
+scalePath :: HasP2 a => P2 -> PathOf a -> PathOf a
 scalePath = scalePoints
 
-scalePathAround :: HasP2 a => P2 -> Double -> PathOf a -> PathOf a
+scalePathAround :: HasP2 a => P2 -> P2 -> PathOf a -> PathOf a
 scalePathAround = scaleAroundPoints
 
 rotatePath :: HasP2 a => Angle -> PathOf a -> PathOf a

--- a/src/ChaosBox/Geometry/Polygon.hs
+++ b/src/ChaosBox/Geometry/Polygon.hs
@@ -6,21 +6,27 @@ module ChaosBox.Geometry.Polygon
   , getPolygon
   , polygonOf
   , polygon
+  , translatePolygon
+  , scalePolygon
+  , scalePolygonAround
+  , rotatePolygon
+  , rotatePolygonAround
   )
 where
 
 import           ChaosBox.Prelude
 
 import           ChaosBox.AABB
-import           ChaosBox.Affine
 import           ChaosBox.Draw
+import           ChaosBox.Geometry.Angle
 import           ChaosBox.Geometry.Class
 import           ChaosBox.Geometry.P2
-import           Control.Lens            ((^.))
-import           Data.Foldable           (for_)
-import           Data.List.NonEmpty      (NonEmpty (..))
-import qualified Data.List.NonEmpty      as NE
-import           GI.Cairo.Render         hiding (Path)
+import           ChaosBox.Geometry.Transform
+import           Control.Lens                ((^.))
+import           Data.Foldable               (for_)
+import           Data.List.NonEmpty          (NonEmpty (..))
+import qualified Data.List.NonEmpty          as NE
+import           GI.Cairo.Render             hiding (Path)
 
 -- | A closed path
 newtype PolygonOf a = PolygonOf { getPolygonOf :: NonEmpty a }
@@ -36,9 +42,6 @@ pattern Polygon {getPolygon} = PolygonOf getPolygon
 instance HasP2 a => HasAABB (PolygonOf a) where
   aabb = boundary . getPolygonOf
 
-instance HasP2 a => Affine (PolygonOf a) where
-  transform = defaultTransform
-
 instance HasP2 a => Draw (PolygonOf a) where
   draw (PolygonOf (v :| rest)) = do
     let V2 startX startY = v ^. _V2
@@ -52,3 +55,18 @@ polygonOf xs = PolygonOf <$> NE.nonEmpty xs
 
 polygon :: [P2] -> Maybe Polygon
 polygon = polygonOf
+
+translatePolygon :: HasP2 a => P2 -> PolygonOf a -> PolygonOf a
+translatePolygon = translatePoints
+
+scalePolygon :: HasP2 a => P2 -> PolygonOf a -> PolygonOf a
+scalePolygon = scalePoints
+
+scalePolygonAround :: HasP2 a => P2 -> P2 -> PolygonOf a -> PolygonOf a
+scalePolygonAround = scaleAroundPoints
+
+rotatePolygon :: HasP2 a => Angle -> PolygonOf a -> PolygonOf a
+rotatePolygon = rotatePoints
+
+rotatePolygonAround :: HasP2 a => P2 -> Angle -> PolygonOf a -> PolygonOf a
+rotatePolygonAround = rotateAroundPoints

--- a/src/ChaosBox/Geometry/Quad.hs
+++ b/src/ChaosBox/Geometry/Quad.hs
@@ -4,25 +4,32 @@ module ChaosBox.Geometry.Quad
   ( QuadOf(..)
   , Quad
   , pattern Quad
+  , fromRect
   , quadA
   , quadB
   , quadC
   , quadD
+  , translateQuad
+  , scaleQuad
+  , scaleQuadAround
+  , rotateQuad
+  , rotateQuadAround
   )
 where
 
 import           ChaosBox.Prelude
 
 import           ChaosBox.AABB
-import           ChaosBox.Affine
 import           ChaosBox.Draw
+import           ChaosBox.Geometry.Angle
 import           ChaosBox.Geometry.Class
 import           ChaosBox.Geometry.P2
-import           ChaosBox.Geometry.Polygon (polygonOf)
+import           ChaosBox.Geometry.Polygon   (polygonOf)
 import           ChaosBox.Geometry.Rect
-import           Control.Lens              ((&), (+~))
-import           Data.Foldable             (for_)
-import           Data.List.NonEmpty        (NonEmpty (..))
+import           ChaosBox.Geometry.Transform
+import           Control.Lens                ((&), (+~))
+import           Data.Foldable               (for_)
+import           Data.List.NonEmpty          (NonEmpty (..))
 
 data QuadOf a = QuadOf
   { quadOfA :: a
@@ -38,16 +45,8 @@ pattern Quad :: P2 -> P2 -> P2 -> P2 -> Quad
 pattern Quad {quadA, quadB, quadC, quadD} = QuadOf quadA quadB quadC quadD
 {-# COMPLETE Quad #-}
 
-instance HasP2 a => Affine (QuadOf a) where
-  transform = defaultTransform
-
 instance HasP2 a => HasAABB (QuadOf a) where
   aabb QuadOf {..} = boundary $ quadOfA :| [quadOfB, quadOfC, quadOfD]
-
--- To avoid cyclic dependencies this orphan instance must be located here
-instance HasP2 a => Affine (RectOf a) where
-  type Transformed (RectOf a) = QuadOf a
-  transform m = transform m . fromRect
 
 instance HasP2 a => Draw (QuadOf a) where
   draw QuadOf {..} = for_ (polygonOf [quadOfA, quadOfB, quadOfC, quadOfD]) draw
@@ -57,3 +56,18 @@ fromRect RectOf {..} = QuadOf rectOfTopLeft
                               (rectOfTopLeft & _V2 +~ V2 rectOfW 0)
                               (rectOfTopLeft & _V2 +~ V2 rectOfW rectOfH)
                               (rectOfTopLeft & _V2 +~ V2 0 rectOfH)
+
+translateQuad :: HasP2 a => P2 -> QuadOf a -> QuadOf a
+translateQuad = translatePoints
+
+scaleQuad :: HasP2 a => P2 -> QuadOf a -> QuadOf a
+scaleQuad = scalePoints
+
+scaleQuadAround :: HasP2 a => P2 -> P2 -> QuadOf a -> QuadOf a
+scaleQuadAround = scaleAroundPoints
+
+rotateQuad :: HasP2 a => Angle -> QuadOf a -> QuadOf a
+rotateQuad = rotatePoints
+
+rotateQuadAround :: HasP2 a => P2 -> Angle -> QuadOf a -> QuadOf a
+rotateQuadAround = rotateAroundPoints

--- a/src/ChaosBox/Geometry/Transform.hs
+++ b/src/ChaosBox/Geometry/Transform.hs
@@ -15,10 +15,10 @@ import           Control.Lens            ((%~))
 translatePoints :: (Functor f, HasP2 a) => P2 -> f a -> f a
 translatePoints p2 = fmap (_V2 %~ translateP2 p2)
 
-scalePoints :: (Functor f, HasP2 a) => Double -> f a -> f a
+scalePoints :: (Functor f, HasP2 a) => P2 -> f a -> f a
 scalePoints amount = fmap (_V2 %~ scaleP2 amount)
 
-scaleAroundPoints :: (Functor f, HasP2 a) => P2 -> Double -> f a -> f a
+scaleAroundPoints :: (Functor f, HasP2 a) => P2 -> P2 -> f a -> f a
 scaleAroundPoints center amount = fmap (_V2 %~ scaleP2Around center amount)
 
 rotatePoints :: (Functor f, HasP2 a) => Angle -> f a -> f a

--- a/src/ChaosBox/Geometry/Transform.hs
+++ b/src/ChaosBox/Geometry/Transform.hs
@@ -1,0 +1,28 @@
+module ChaosBox.Geometry.Transform
+  ( translatePoints
+  , scalePoints
+  , scaleAroundPoints
+  , rotatePoints
+  , rotateAroundPoints
+  )
+where
+
+import           ChaosBox.Geometry.Angle
+import           ChaosBox.Geometry.Class
+import           ChaosBox.Geometry.P2
+import           Control.Lens            ((%~))
+
+translatePoints :: (Functor f, HasP2 a) => P2 -> f a -> f a
+translatePoints p2 = fmap (_V2 %~ translateP2 p2)
+
+scalePoints :: (Functor f, HasP2 a) => Double -> f a -> f a
+scalePoints amount = fmap (_V2 %~ scaleP2 amount)
+
+scaleAroundPoints :: (Functor f, HasP2 a) => P2 -> Double -> f a -> f a
+scaleAroundPoints center amount = fmap (_V2 %~ scaleP2Around center amount)
+
+rotatePoints :: (Functor f, HasP2 a) => Angle -> f a -> f a
+rotatePoints theta = fmap (_V2 %~ rotateP2 theta)
+
+rotateAroundPoints :: (Functor f, HasP2 a) => P2 -> Angle -> f a -> f a
+rotateAroundPoints center theta = fmap (_V2 %~ rotateP2Around center theta)

--- a/src/ChaosBox/Geometry/Triangle.hs
+++ b/src/ChaosBox/Geometry/Triangle.hs
@@ -6,21 +6,27 @@ module ChaosBox.Geometry.Triangle
   , triangleA
   , triangleB
   , triangleC
+  , translateTriangle
+  , scaleTriangle
+  , scaleTriangleAround
+  , rotateTriangle
+  , rotateTriangleAround
   )
 where
 
 import           ChaosBox.Prelude
 
 import           ChaosBox.AABB
-import           ChaosBox.Affine
 import           ChaosBox.Draw
+import           ChaosBox.Geometry.Angle
 import           ChaosBox.Geometry.Class
 import           ChaosBox.Geometry.P2
 import           ChaosBox.Geometry.Polygon
-import           Control.Lens              ((^.))
-import           Data.Function             (on)
-import           Data.List                 (sortBy)
-import           Data.List.NonEmpty        (NonEmpty (..))
+import           ChaosBox.Geometry.Transform
+import           Control.Lens                ((^.))
+import           Data.Function               (on)
+import           Data.List                   (sortBy)
+import           Data.List.NonEmpty          (NonEmpty (..))
 
 data TriangleOf a = TriangleOf
   { triangleOfA :: a
@@ -31,9 +37,6 @@ data TriangleOf a = TriangleOf
 
 instance HasP2 a => HasAABB (TriangleOf a) where
   aabb = aabb . toPolygon
-
-instance HasP2 a => Affine (TriangleOf a) where
-  transform = defaultTransform
 
 instance HasP2 a => Draw (TriangleOf a) where
   draw = draw . toPolygon
@@ -70,3 +73,18 @@ sortOnPolarAngle []       = []
 sortOnPolarAngle [x     ] = [x]
 sortOnPolarAngle (x : xs) = x : sortBy (compare `on` polarAngle x) xs
   where polarAngle a b = negate $ (b ^. _x - a ^. _x) / (b ^. _y - a ^. _y)
+
+translateTriangle :: HasP2 a => P2 -> TriangleOf a -> TriangleOf a
+translateTriangle = translatePoints
+
+scaleTriangle :: HasP2 a => P2 -> TriangleOf a -> TriangleOf a
+scaleTriangle = scalePoints
+
+scaleTriangleAround :: HasP2 a => P2 -> P2 -> TriangleOf a -> TriangleOf a
+scaleTriangleAround = scaleAroundPoints
+
+rotateTriangle :: HasP2 a => Angle -> TriangleOf a -> TriangleOf a
+rotateTriangle = rotatePoints
+
+rotateTriangleAround :: HasP2 a => P2 -> Angle -> TriangleOf a -> TriangleOf a
+rotateTriangleAround = rotateAroundPoints


### PR DESCRIPTION
`Affine` was a fun idea but it gets confusing fast. I'm thinking it's much simpler to just expose the following for each data type and rely on the user to use the appropriate one for whatever shape they're working with:

```haskell
translate{Shape} :: P2 -> Shape -> Shape
scale{Shape} :: P2 -> Shape -> Shape
scaleAround{Shape} :: P2 -> P2 -> Shape -> Shape
rotate{Shape} :: P2 -> Shape -> Shape
rotateAround{Shape} :: P2 -> P2 -> Shape -> Shape
```

This ends up being more flexible anyway: instead of relying on all transformations producing the same data type (`type Transformed a`), it can vary when needed. For example, for `Circle`s to scale in multiple directions, the data type must change. For that reason, the type of `scaleCircle` has just been modified to accept only a scalar. Additionally, performing any transformation operation on a `Circle` in the previous version produced a `Polygon`. That's not necessary for scaling or rotating but it was forced to abide by the `Affine` contract which made it necessary.

This is just a must simpler starting point to build from.