### PR TITLE
Add center functions for all primitive geometric types

### DIFF
--- a/src/ChaosBox/Geometry/ClosedCurve.hs
+++ b/src/ChaosBox/Geometry/ClosedCurve.hs
@@ -7,6 +7,7 @@ module ChaosBox.Geometry.ClosedCurve
   , closedCurveIterations
   , closedCurve
   , closedCurveOf
+  , closedCurveCenter
   , drawWithDetail
   , fromPolygon
   , toPolygon
@@ -18,6 +19,7 @@ module ChaosBox.Geometry.ClosedCurve
   )
 where
 
+import           ChaosBox.Math (average)
 import           ChaosBox.AABB
 import           ChaosBox.Draw
 import           ChaosBox.Geometry.Angle
@@ -99,3 +101,7 @@ rotateClosedCurve = rotatePoints
 
 rotateClosedCurveAround :: HasP2 a => P2 -> Angle -> ClosedCurveOf a -> ClosedCurveOf a
 rotateClosedCurveAround = rotateAroundPoints
+
+-- | The center of mass of a 'ClosedCurve'
+closedCurveCenter :: HasP2 a => ClosedCurveOf a -> P2
+closedCurveCenter = average . fmap (^._V2)

--- a/src/ChaosBox/Geometry/Curve.hs
+++ b/src/ChaosBox/Geometry/Curve.hs
@@ -10,6 +10,7 @@ module ChaosBox.Geometry.Curve
   , curveWithDetail
   , toPath
   , fromPath
+  , curveCenter
   )
 where
 
@@ -22,6 +23,7 @@ import           Control.Lens
 import           Data.List.NonEmpty      (NonEmpty (..))
 import qualified Data.List.NonEmpty      as NE
 import           GI.Cairo.Render         (Render)
+import           ChaosBox.Math (average)
 
 -- | Cubic B-Spline
 data CurveOf a = CurveOf { getCurveOf :: NonEmpty a, curveOfIterations :: Int }
@@ -76,3 +78,7 @@ curve = curveOf @P2
 
 curveWithDetail :: [a] -> Int -> Maybe (CurveOf a)
 curveWithDetail xs detail = CurveOf <$> NE.nonEmpty xs <*> pure detail
+
+-- | The center of mass of a 'Curve'
+curveCenter :: HasP2 a => CurveOf a -> P2
+curveCenter = average . fmap (^._V2)

--- a/src/ChaosBox/Geometry/Line.hs
+++ b/src/ChaosBox/Geometry/Line.hs
@@ -6,6 +6,7 @@ module ChaosBox.Geometry.Line
   , pattern Line
   , lineStart
   , lineEnd
+  , lineCenter
   -- * Transforming 'Line's
   , translateLine
   , scaleLine
@@ -26,6 +27,8 @@ import           Data.List.NonEmpty
 import           Data.Maybe                  (maybeToList)
 import           Linear.V2                   (V2 (..))
 import           Linear.Vector               ((*^))
+import           Control.Lens ((^.))
+import           ChaosBox.Math (average)
 
 data LineOf a = LineOf { lineOfStart :: a, lineOfEnd :: a}
   deriving stock (Show, Eq, Ord, Functor, Foldable, Traversable)
@@ -81,3 +84,7 @@ rotateLine = rotatePoints
 
 rotateLineAround :: HasP2 a => P2 -> Angle -> LineOf a -> LineOf a
 rotateLineAround = rotateAroundPoints
+
+-- | The center of mass of a 'Line'
+lineCenter :: HasP2 a => LineOf a -> P2
+lineCenter = average . fmap (^._V2)

--- a/src/ChaosBox/Geometry/Path.hs
+++ b/src/ChaosBox/Geometry/Path.hs
@@ -9,11 +9,13 @@ module ChaosBox.Geometry.Path
   , scalePathAround
   , rotatePath
   , rotatePathAround
+  , pathCenter
   )
 where
 
 import           ChaosBox.Prelude
 
+import           ChaosBox.Math (average)
 import           ChaosBox.AABB
 import           ChaosBox.Draw
 import           ChaosBox.Geometry.Angle
@@ -59,3 +61,7 @@ rotatePath = rotatePoints
 
 rotatePathAround :: HasP2 a => P2 -> Angle -> PathOf a -> PathOf a
 rotatePathAround = rotateAroundPoints
+
+-- | The center of mass of a 'Path'
+pathCenter :: HasP2 a => PathOf a -> P2
+pathCenter = average . fmap (^._V2)

--- a/src/ChaosBox/Geometry/Polygon.hs
+++ b/src/ChaosBox/Geometry/Polygon.hs
@@ -6,6 +6,7 @@ module ChaosBox.Geometry.Polygon
   , getPolygon
   , polygonOf
   , polygon
+  , polygonCenter
   , translatePolygon
   , scalePolygon
   , scalePolygonAround
@@ -16,6 +17,7 @@ where
 
 import           ChaosBox.Prelude
 
+import           ChaosBox.Math (average)
 import           ChaosBox.AABB
 import           ChaosBox.Draw
 import           ChaosBox.Geometry.Angle
@@ -70,3 +72,7 @@ rotatePolygon = rotatePoints
 
 rotatePolygonAround :: HasP2 a => P2 -> Angle -> PolygonOf a -> PolygonOf a
 rotatePolygonAround = rotateAroundPoints
+
+-- | The center of mass of a 'Polygon'
+polygonCenter :: HasP2 a => PolygonOf a -> P2
+polygonCenter = average . fmap (^._V2)

--- a/src/ChaosBox/Geometry/Quad.hs
+++ b/src/ChaosBox/Geometry/Quad.hs
@@ -14,11 +14,14 @@ module ChaosBox.Geometry.Quad
   , scaleQuadAround
   , rotateQuad
   , rotateQuadAround
+  , quadCenter
   )
 where
 
 import           ChaosBox.Prelude
 
+import           ChaosBox.Math (average)
+import           Control.Lens ((^.))
 import           ChaosBox.AABB
 import           ChaosBox.Draw
 import           ChaosBox.Geometry.Angle
@@ -71,3 +74,7 @@ rotateQuad = rotatePoints
 
 rotateQuadAround :: HasP2 a => P2 -> Angle -> QuadOf a -> QuadOf a
 rotateQuadAround = rotateAroundPoints
+
+-- | The center of mass of a 'Quad'
+quadCenter :: HasP2 a => QuadOf a -> P2
+quadCenter = average . fmap (^._V2)

--- a/src/ChaosBox/Geometry/Rect.hs
+++ b/src/ChaosBox/Geometry/Rect.hs
@@ -7,6 +7,7 @@ module ChaosBox.Geometry.Rect
   , rectTopLeft
   , rectW
   , rectH
+  , rectCenter
   -- * Smart constructors
   , squareOf
   , square
@@ -58,6 +59,10 @@ pattern Rect { rectTopLeft, rectW, rectH} = RectOf rectTopLeft rectW rectH
 
 fromAABB :: AABB -> Rect
 fromAABB (AABB tl w h) = RectOf tl w h
+
+-- | The center of a 'Rect'
+rectCenter :: HasP2 a => RectOf a -> P2
+rectCenter RectOf{..} = (rectOfTopLeft^._V2) + (P2 rectOfW rectOfH / 2)
 
 --
 -- There are a LOT of ways this can happen. let's enumerate them

--- a/src/ChaosBox/Geometry/Triangle.hs
+++ b/src/ChaosBox/Geometry/Triangle.hs
@@ -6,6 +6,7 @@ module ChaosBox.Geometry.Triangle
   , triangleA
   , triangleB
   , triangleC
+  , triangleCenter
   , translateTriangle
   , scaleTriangle
   , scaleTriangleAround
@@ -16,6 +17,7 @@ where
 
 import           ChaosBox.Prelude
 
+import           ChaosBox.Math (average)
 import           ChaosBox.AABB
 import           ChaosBox.Draw
 import           ChaosBox.Geometry.Angle
@@ -88,3 +90,7 @@ rotateTriangle = rotatePoints
 
 rotateTriangleAround :: HasP2 a => P2 -> Angle -> TriangleOf a -> TriangleOf a
 rotateTriangleAround = rotateAroundPoints
+
+-- | The center of mass of a 'Triangle'
+triangleCenter :: HasP2 a => TriangleOf a -> P2
+triangleCenter = average . fmap (^._V2)


### PR DESCRIPTION
These are useful for scaling and rotating around. For example:

```haskell
rotateQuadAround (quadCenter quad) (fromRadians pi/2) quad
```

is *probably* more intuitive behavior than what `rotateQuad` does (rotate around the origin).

Having these centering functions in place is a stepping stone for making generic machinery around scaling and rotating about the center of an object.