### PR TITLE
Rendering images to SVG/PDF/PS in static mode

### DIFF
--- a/src/ChaosBox/CLI.hs
+++ b/src/ChaosBox/CLI.hs
@@ -75,6 +75,11 @@ import           Foreign.Ptr                    ( castPtr )
 import           SDL
 
 data RenderMode = Static | Interactive
+data FileFormat = PNG
+                | SVG
+                | PS
+                | PDF
+  deriving (Read, Show, Eq)
 
 -- | ChaosBox's options
 data Opts = Opts
@@ -95,8 +100,10 @@ data Opts = Opts
   -- ^ Optional string to append to file name, useful for tagging
   , optFps            :: Int
   -- ^ How many frames an interactive video should render per second
-  , optRenderMode :: RenderMode
+  , optRenderMode     :: RenderMode
   -- ^ Should the program render a png directly or spawn an interactive video?
+  , optFileFormat     :: FileFormat
+  -- ^ Which file format to use for saving images
   }
 
 getDefaultOpts :: IO Opts
@@ -111,6 +118,7 @@ getDefaultOpts = do
             , optMetadataString = Nothing
             , optFps            = 30
             , optRenderMode     = Interactive
+            , optFileFormat     = PNG
             }
 
 opts :: Parser Opts
@@ -145,6 +153,7 @@ opts =
           )
     <*> option auto (long "fps" <> metavar "FPS" <> value 30 <> help fpsHelp)
     <*> flag Interactive Static (long "static" <> short 's' <> help staticHelp)
+    <*> option auto (long "fileformat"<> short 'f' <> metavar "FILEFORMAT" <> help fileformatHelp <> value PNG )
  where
   seedHelp     = "Seed for the global PRNG (optional)"
   scaleHelp    = "Scaling factor from user space to image space (default: 1)"
@@ -157,6 +166,7 @@ opts =
     "How many frames per second to render in interactive mode (default: 30)"
   staticHelp
     = "Render an image directly instead of in an interactive window (default: False)"
+  fileformatHelp = "Fileformat used for images: PNG, SVG, PS or PDF (default: PNG)"
 
 optsInfo :: ParserInfo Opts
 optsInfo = info


### PR DESCRIPTION
Related to #9. This pull-request adds functionality for rendering to other file types in static mode. I didn't know exactly how the rendering worked so I though it would be easy to add rendering images to SVG, but I learned this is not the case. The surface used for the SDL window is (obviously) pixel based and therefore can be easily put onto a PNG file. However, rendering to SVG for example needs all the rendering to be done again. Saving images in interactive mode is therefore not that easy since access is needed to the sketch, the cairo surface is not enough. There are probably multiple ways to work around this issue, but for now I just implemented rendering to different file types in static mode.

This pull requests add an option `fileFormat` with possibilities `PNG`, `SVG`, `PDF` and `PS`. When using static mode, the rendering is done to the specified `fileFormat`, and defaults to `PNG`. `PNG` behavior is unchanged.